### PR TITLE
Add dex_cpu_utilization_seconds_total metric

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Exports container state (running or not), current cpu and memory utilization, ne
 - `dex_block_io_write_bytes`
 - `dex_container_running`
 - `dex_cpu_utilization_percent`
+- `dex_cpu_utilization_seconds_total`
 - `dex_memory_total_bytes`
 - `dex_memory_usage_bytes`
 - `dex_memory_utilization_percent`


### PR DESCRIPTION
This PR adds a new metric `dex_cpu_utilization_seconds_total` which is a counter of the total number of CPU seconds used by the container since the start. This metric is useful in scenarios where it is needed an overall system utilization over time. The idea of adding a new metric instead of updating the current one is to keep the compatibility with the current dashboards. Fixes #70.