### PR TITLE
Remove default go runtime metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,13 @@ import (
 )
 
 func main() {
-	prometheus.MustRegister(newDockerCollector())
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(newDockerCollector())
 
 	router := http.NewServeMux()
-	router.Handle("/metrics", promhttp.Handler())
+	router.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		Registry: reg,
+	}))
 
 	serverPort := 8080
 


### PR DESCRIPTION
This PR removes the Go runtime metrics from the metrics that are being exported.

From [client_golang](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus) documentation:

"Also note that the DefaultRegisterer comes registered with a Collector for Go runtime metrics (via NewGoCollector) and a Collector for process metrics (via NewProcessCollector). With a custom registry, you are in control and decide yourself about the Collectors to register."

While I think these are good metrics to have for a business application dealing with domain traffic, being this application solely an exporter of metrics and being it so lightweight, these runtime and process metrics do not really matter and are only filling upstream Prometheus with additional time-series.

Before:
(dex metrics + go runtime)
![image](https://github.com/0xERR0R/dex/assets/11997784/c578cb8a-f9a6-4da7-b3e6-bdacc2d3e651)

After:
(only dex metrics)
![image](https://github.com/0xERR0R/dex/assets/11997784/c5dc987a-f5f0-4d66-8f3d-4f3c54b230ff)
