### PR TITLE
Add versioning to the docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
   push:
 
 jobs:
-  build:
 
+  build:
+    name: Build
     runs-on: ubuntu-latest
+    env:
+      SHOULD_PUSH: ${{ github.repository_owner == '0xERR0R' && github.ref == 'refs/heads/master' }}
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -18,22 +22,37 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-        id: go
+
+      - name: Build
+        run: make build
 
       - name: Set up Docker Buildx
-        id: buildx
+        if: env.SHOULD_PUSH == 'true'
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
 
-      - name: Build
-        run: make build
-        
+      - name: Get next version
+        id: version
+        if: env.SHOULD_PUSH == 'true'
+        uses: reecetech/version-increment@2023.10.2
+        with:
+          scheme: semver
+          increment: patch
+
+      - name: Set Version
+        if: env.SHOULD_PUSH == 'true'
+        run: |
+          git tag ${{ steps.version.outputs.v-version }}
+          git push origin ${{ steps.version.outputs.v-version }}
+
       - name: Login to DockerHub
+        if: env.SHOULD_PUSH == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build the Docker image and push
-        run: make docker-buildx-push
+        if: env.SHOULD_PUSH == 'true'
+        run: make docker-buildx-push DOCKER_TAG=${{ steps.version.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,24 @@
 .PHONY: build docker-build docker-buildx-push help
 .DEFAULT_GOAL := help
 
-DOCKER_IMAGE_NAME="spx01/dex"
+DOCKER_IMAGE_NAME=spx01/dex
+DOCKER_TAG=latest
 BINARY_NAME=dex
 BIN_OUT_DIR=bin
-
 
 
 build:  ## Build binary
 	go build -v -ldflags="-w -s" -o $(BIN_OUT_DIR)/$(BINARY_NAME)
 
-
 docker-buildx-push:  ## Build multi arch docker images and push
 	docker buildx build \
-            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
-            --tag ${DOCKER_IMAGE_NAME}:latest --push .
+		--platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
+		--tag $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) \
+		--tag $(DOCKER_IMAGE_NAME):latest \
+		--push .
 
 docker-build:  ## Build docker image
-	docker build --network=host --tag ${DOCKER_IMAGE_NAME} .
+	docker build --network=host --tag $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) .
 
 help:  ## Shows help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR changes Github actions to run a Go build and CodeQL on every branch of every fork, but only try to publish a docker image from the master branch from [0xERR0R](https://github.com/0xERR0R). It will also tag the docker image with an auto incrementing patch semver (0.0.x) and tag the commit with the same version with the `v` prefix (v0.0.x). Major and minor versions should be manually created by `git tag` and the Github action will pick that up and continue from there.

The reasoning behind removing docker push from all repositories not owned by [0xERR0R](https://github.com/0xERR0R) is to not bother users with forks with errors, due to not having the secrets for docker hub defined.

 Fixes #75.